### PR TITLE
Support serializing Vec<T> as an attribute

### DIFF
--- a/yaserde/tests/serializer.rs
+++ b/yaserde/tests/serializer.rs
@@ -415,3 +415,30 @@ fn ser_custom() {
   let content = "<Date><Year>2020</Year><Month>1</Month><DoubleDay>10</DoubleDay></Date>";
   serialize_and_validate!(model, content);
 }
+
+#[test]
+fn ser_vec_as_attribute() {
+  #[derive(YaSerialize, PartialEq, Debug)]
+  #[yaserde(rename = "TestTag")]
+  pub struct VecAttributeStruct {
+    #[yaserde(attribute = true)]
+    numbers: Vec<u32>,
+    #[yaserde(attribute = true)]
+    strings: Vec<String>,
+    #[yaserde(attribute = true)]
+    bools: Vec<bool>,
+    #[yaserde(attribute = true)]
+    floats: Vec<f64>,
+  }
+
+  let model = VecAttributeStruct {
+    numbers: vec![1, 2, 3, 4],
+    strings: vec!["hello".to_string(), "world".to_string()],
+    bools: vec![true, false, true],
+    floats: vec![3.14, 2.71],
+  };
+
+  // Expected XML with space-separated attribute values
+  let content = r#"<TestTag numbers="1 2 3 4" strings="hello world" bools="true false true" floats="3.14 2.71" />"#;
+  serialize_and_validate!(model, content);
+}

--- a/yaserde_derive/src/ser/expand_struct.rs
+++ b/yaserde_derive/src/ser/expand_struct.rs
@@ -115,9 +115,36 @@ pub fn serialize(
               struct_start_event.attr(#label_name, &yaserde_inner)
             }),
           ),
-          Field::FieldVec { .. } => {
-            // TODO
-            quote!()
+          Field::FieldVec { data_type } => match *data_type {
+            Field::FieldString
+            | Field::FieldBool
+            | Field::FieldI8
+            | Field::FieldU8
+            | Field::FieldI16
+            | Field::FieldU16
+            | Field::FieldI32
+            | Field::FieldU32
+            | Field::FieldI64
+            | Field::FieldU64
+            | Field::FieldF32
+            | Field::FieldF64 => field.ser_wrap_default_attribute(
+              Some(quote! {
+                self.#label
+                  .iter()
+                  .map(|item| item.to_string())
+                  .collect::<::std::vec::Vec<_>>()
+                  .join(" ")
+              }),
+              quote!({
+                struct_start_event.attr(#label_name, &yaserde_inner)
+              }),
+            ),
+            Field::FieldOption { .. } | Field::FieldVec { .. } => {
+              unimplemented!("Nested Option or Vec in Vec not supported for attributes")
+            }
+            Field::FieldStruct { .. } => {
+              unimplemented!("Struct fields in Vec not supported for attributes")
+            }
           }
         }
       } else {


### PR DESCRIPTION
This is already supported in deserializing, so adding the other side now.


Example:
```
#[yaserde(attribute = true)]
field: Vec<u32>
```

should serialize into `<MyTag field="1 2 3" />`